### PR TITLE
Register JSON type mapper

### DIFF
--- a/lib/redshift/client/connection.rb
+++ b/lib/redshift/client/connection.rb
@@ -9,6 +9,7 @@ module Redshift
 
       def initialize(configuration)
         @original = PG.connect(configuration.params)
+        @original.type_map_for_results = PG::BasicTypeMapForResults.new(@original)
       end
 
       def_delegators \
@@ -19,8 +20,7 @@ module Redshift
         :escape_string,
         :escape_literal,
         :close,
-        :transaction,
-        :quote_ident
+        :transaction
     end
   end
 end

--- a/spec/redshift/client/connection_spec.rb
+++ b/spec/redshift/client/connection_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 
 describe Redshift::Client::Connection do
   let(:configuration) { Redshift::Client::Configuration.resolve }
+  let(:connection) { double('connection', 'type_map_for_results=' => nil, 'exec' => nil) }
 
   describe "#initialize" do
     before do
@@ -9,8 +10,25 @@ describe Redshift::Client::Connection do
     end
 
     it "calls PG#connect" do
+      expect(PG)
+        .to receive(:connect)
+        .with(configuration.params)
+        .once
+        .and_call_original
       Redshift::Client::Connection.new(configuration)
-      expect(PG).to have_received(:connect).with(configuration.params).once
+    end
+
+    it "registers basic type maps for JSON parsing" do
+      expect(PG)
+        .to receive(:connect)
+        .with(configuration.params)
+        .once
+        .and_return(connection)
+      expect(PG::BasicTypeMapForResults)
+        .to receive(:new)
+        .with(connection)
+        .once
+      Redshift::Client::Connection.new(configuration)
     end
   end
 end


### PR DESCRIPTION
Adding the basic type mappers the connection results will be parsed which also applies to JSONb fiields which will be mapped to ruby hashes