### PR TITLE
Use method missing for delegating method calls

### DIFF
--- a/lib/redshift/client/connection.rb
+++ b/lib/redshift/client/connection.rb
@@ -11,16 +11,17 @@ module Redshift
         @original = PG.connect(configuration.params)
       end
 
-      def_delegators \
-        :@original,
-        :exec,
-        :exec_params,
-        :escape,
-        :escape_string,
-        :escape_literal,
-        :close,
-        :transaction,
-        :quote_ident
+      def method_missing(method_name, *args, &block)
+        if @original.respond_to?(method_name)
+          @original.send(method_name, *args, &block)
+        else
+          super
+        end
+      end
+
+      def respond_to_missing?(method_name, include_private = false)
+        @original.respond_to?(method_name, include_private) || super
+      end
     end
   end
 end


### PR DESCRIPTION
With method missing we will be able to delegate methods to PG connection without specifying a list.
Although this dont limit the delegated methods we will always depends on the connection, so the client will be able to use those methods anytime