### PR TITLE
Cast timezones properly to application timezone

### DIFF
--- a/lib/redshift/client/connection.rb
+++ b/lib/redshift/client/connection.rb
@@ -7,7 +7,7 @@ module Redshift
 
       def initialize(configuration)
         @original = PG.connect(configuration.params)
-        @original.type_map_for_results = PG::BasicTypeMapForResults.new(@original)
+        @original.type_map_for_results = extended_type_map_for(@original)
       end
 
       def method_missing(method_name, *args, &block)
@@ -20,6 +20,22 @@ module Redshift
 
       def respond_to_missing?(method_name, include_private = false)
         @original.respond_to?(method_name, include_private) || super
+      end
+
+      private
+
+      def extended_type_map_for(connection)
+        PG::BasicTypeMapForResults.new(connection, registry: registry)
+      end
+
+      def registry
+        # PG::BasicTypeMap assumes DB is in the same tz as application
+        # This extension supports Database which stores data in UTC if the column type is timezone(without zone)
+        timestamp_tz_parser_klass = PG::TextDecoder::TimestampUtcToLocal
+        registry = PG::BasicTypeRegistry.new
+        registry.register_default_types
+        registry.register_type(0, 'timestamp', PG::TextEncoder::TimestampWithoutTimeZone, timestamp_tz_parser_klass)
+        registry
       end
 
     end

--- a/spec/redshift/client/connection_spec.rb
+++ b/spec/redshift/client/connection_spec.rb
@@ -3,10 +3,19 @@ require 'spec_helper'
 describe Redshift::Client::Connection do
   let(:configuration) { Redshift::Client::Configuration.resolve }
   let(:connection) { double('connection', 'type_map_for_results=' => nil, 'exec' => nil) }
+  let(:registry) { double('registry') }
 
   describe "#initialize" do
     before do
       allow(PG).to receive(:connect)
+      allow(PG::BasicTypeRegistry).to receive(:new).and_return(registry)
+      allow(registry)
+        .to receive(:register_default_types)
+      allow(registry)
+        .to receive(:coders_for)
+      allow(registry)
+        .to receive(:register_type)
+        .with(0, 'timestamp', PG::TextEncoder::TimestampWithoutTimeZone, PG::TextDecoder::TimestampUtcToLocal)
     end
 
     it "calls PG#connect" do
@@ -26,7 +35,7 @@ describe Redshift::Client::Connection do
         .and_return(connection)
       expect(PG::BasicTypeMapForResults)
         .to receive(:new)
-        .with(connection)
+        .with(connection, registry: registry)
         .once
       Redshift::Client::Connection.new(configuration)
     end


### PR DESCRIPTION
PG connection originally suppose the DB timezone is in the same as application timezone if you use basic type map provided by the gem.

When pg decodes the result it is using the client timezone but not adding the offset for the UTC value
eg: updated_at in column: '2023-06-16 12:33:11' is parsed as '2023-06-16 12:33:11 +1000' if you application timezone is in +10. 

PG supported coders: https://deveiate.org/code/pg/README_md.html#label-Type+Casts

Basic type map using [TimestampLocal](https://github.com/ged/ruby-pg/blob/6629dec6656f7ca27619e4675b45225d9e422112/lib/pg/text_decoder/timestamp.rb#L19) which causes the bug in our case since the DB is in UTC.

For the fix we needed to register [TimestampUtcToLocal](https://github.com/ged/ruby-pg/blob/6629dec6656f7ca27619e4675b45225d9e422112/lib/pg/text_decoder/timestamp.rb#L13) to decode properly timestamps
